### PR TITLE
Changed hardcoded osteppy link to bbb.cdot.systems

### DIFF
--- a/Dashboard/src/config.js
+++ b/Dashboard/src/config.js
@@ -2,7 +2,7 @@
 const dashHost = process.env.REACT_APP_OSTEP_DASH_HOST || "localhost";
 
 export default {
-  osteppy: `http://narnia.cdot.systems:8081/eod`,
+  osteppy: `http://bbb.cdot.systems:8081/eod`,
   lamp: `http://${dashHost}:8082`,
   presentations: `http://${dashHost}:8083`,
   meetings: `http://${dashHost}:8084`,


### PR DESCRIPTION
Updated osteppy location to `bbb` (since the dashboard has migrated).
The link is hardcoded (not `http://${dashHost}:`) since osteppy slack is always pointing to it.