### PR TITLE
Parse Slack usernames

### DIFF
--- a/Dashboard/src/App.css
+++ b/Dashboard/src/App.css
@@ -270,7 +270,9 @@ OSTEPPY PANEL
 ==================================== 
 */
 
-
+.eod-list h3:not(:first-child) {
+  margin-top: 2rem;
+}
 
 .slack-icon {
   height: 1.5em;

--- a/Dashboard/src/components/Osteppy.js
+++ b/Dashboard/src/components/Osteppy.js
@@ -77,8 +77,13 @@ class Osteppy extends Container {
       >
         {data &&
           <div className="eod-list">
-            <EODList title="Today's EODs" eods={currentEods} />
-            <EODList title="Past EODs" eods={oldEods} />
+            {currentEods.length > 0 &&
+              <EODList title="Today's EODs" eods={currentEods} />
+            }
+
+            {oldEods.length > 0 &&
+              <EODList title="Past EODs" eods={oldEods} />
+            }
           </div>
         }
       </Panel>

--- a/Dashboard/src/components/Osteppy.js
+++ b/Dashboard/src/components/Osteppy.js
@@ -5,6 +5,20 @@ import slack from './assets/slack.svg';
 import ReactMarkdown from 'react-markdown';
 const COMPONENT_NAME = "osteppy";
 
+// Reformat Slack messages based on:
+// https://api.slack.com/messaging/composing/formatting#retrieving-messages
+function reformatSlackMentions(text) {
+  return text.replace(/<(.*?)>/g, (match, p1) => {
+    switch(p1[0]) {
+      case '@': // content starting with `@U` or `@W` is a user mention
+        return `**${p1.split('|')[1]}**`;
+      default: // content we don't yet know how to format
+        console.warn(`Unknown mention: ${match}`);
+        return match
+    }
+  });
+}
+
 class Osteppy extends Container {
   constructor(props) {
     super(props, COMPONENT_NAME);
@@ -41,7 +55,7 @@ class Osteppy extends Container {
                   <p className="slack-post"> posted EOD in channel </p>
                   <div className="github-repo">{`#${currentEods[username].channel}`}</div>:
                  </div>
-                <ReactMarkdown source={currentEods[username].text} />
+                <ReactMarkdown source={reformatSlackMentions(currentEods[username].text)} />
               </div>
             ))}
             {Object.keys(oldEods).length !== 0 && <h3 className="u-margin-top-small">Past EODs</h3>}
@@ -54,7 +68,7 @@ class Osteppy extends Container {
                   <span className="github-repo"> {`#${oldEods[username].channel}`}</span>:
                 </div>
                 <ReactMarkdown
-                  source={oldEods[username].text}
+                  source={reformatSlackMentions(oldEods[username].text)}
                   className="slack-message"
                 />
               </div>

--- a/Dashboard/src/components/Osteppy.js
+++ b/Dashboard/src/components/Osteppy.js
@@ -11,9 +11,12 @@ const COMPONENT_NAME = "osteppy";
 // https://api.slack.com/messaging/composing/formatting#retrieving-messages
 function reformatSlackMentions(text) {
   return text.replace(/<(.*?)>/g, (match, p1) => {
-    switch(p1[0]) {
-      case '@': // content starting with `@U` or `@W` is a user mention
+    switch(p1.slice(0, 2)) {
+      case '@U': // content starting with `@U` or `@W` is a user mention
+      case '@W':
         return `**${p1.split('|')[1]}**`;
+      case '#C': // content starting with `#C` is a channel link
+        return `**#${p1.split('|')[1]}**`
       default: // content we don't yet know how to format
         console.warn(`Unknown mention: ${match}`);
         return match


### PR DESCRIPTION
Parse Slack usernames based on Slack's directives for [retrieving formatted messages](https://api.slack.com/messaging/composing/formatting#retrieving-messages).

The string `<@UJFPKA3A4|stuart.crust>` now appears as **stuart.crust** in the dashboard. I'm open to suggestions on formatting, but I figured bold would be a good start to differentiate the names. The name after the `|` in the mention matches the `username` displayed, so it didn't require a separate API call to get the data.

Also did some cleanup on the `Osteppy` component.

Closes #52.