### PR TITLE
Clean up Osteppy server

### DIFF
--- a/Osteppy/.eslintrc.json
+++ b/Osteppy/.eslintrc.json
@@ -13,5 +13,6 @@
         "sourceType": "module"
     },
     "rules": {
+        "no-console": "off"
     }
 }

--- a/Osteppy/src/EODList.js
+++ b/Osteppy/src/EODList.js
@@ -1,0 +1,54 @@
+export default class EODList {
+  constructor({
+    dataFile = path.join(__dirname, "eods.json"),
+    unsubmittedNamesFile = path.join(__dirname, "sleepyRAs.txt")
+  } = {}) {
+    this.reportData = {};
+    this.dataFile = dataFile;
+    this.unsubmittedNames = [];
+    this.unsubmittedNamesFile = unsubmittedNamesFile;
+  }
+
+  async load() {
+    const results = await Promise.all([
+      fs.promises.readFile(this.dataFile, { encoding: "utf8", flag: "a+" }),
+      fs.promises.readFile(this.unsubmittedNamesFile, {
+        encoding: "utf8",
+        flag: "a+"
+      })
+    ]);
+    const [reportData, unsubmittedNames] = results;
+
+    try {
+      this.reportData = JSON.parse(reportData);
+    } catch (e) {
+      console.log(`Error parsing ${this.dataFile}: ${e}`);
+    }
+
+    this.unsubmittedNames = unsubmittedNames.split("\n");
+  }
+
+  save() {
+    return Promise.all([
+      fs.promises.writeFile(this.dataFile, JSON.stringify(this.reportData)),
+      fs.promises.writeFile(
+        this.unsubmittedNamesFile,
+        this.unsubmittedNames.join("\n")
+      )
+    ]);
+  }
+
+  submit(name, data) {
+    this.reportData[name] = data;
+    this.unsubmittedNames = this.unsubmittedNames.filter(n => n !== name);
+    return this.save();
+  }
+
+  missing() {
+    return this.unsubmittedNames;
+  }
+
+  report() {
+    return this.reportData;
+  }
+}

--- a/Osteppy/src/server.js
+++ b/Osteppy/src/server.js
@@ -1,32 +1,79 @@
 #!/usr/bin/env node
 
-/***********************************************************
+/** ********************************************************
 // OSTEP Dashboard Osteppy API
 // server.cpp
 // Date Created: 2018/09/11
 // Author: Olga Belavina and Yiran Zhu
 // Email: yzhu132@myseneca.ca
-// Description: Slack API triggered by and responds to 
-// slash commands such as /eod and /eod_left. 
-***********************************************************/
+// Description: Slack API triggered by and responds to
+// slash commands such as /eod and /eod_left.
+********************************************************* */
 
 import http from 'http';
 import express from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
 import bodyParser from 'body-parser';
-import config from './config.json';
 import axios from 'axios';
 import * as fs from 'fs';
+import config from './config.json';
 
 const app = express();
-const data_file = './eods.json';
-const eodNames = __dirname + '/sleepyRAs.txt';
-let RAs = fs.readFileSync(eodNames).toString().split("\n");
-const clock_path = __dirname + '/clock.txt';
-const execSync = require('child_process').execSync;
+const dataFile = './eods.json';
+const eodNames = `${__dirname}/sleepyRAs.txt`;
+let RAs = fs.readFileSync(eodNames).toString().split('\n');
+const clockPath = `${__dirname}/clock.txt`;
+const { execSync } = require('child_process');
 const cp = require('child_process');
-cp.fork(__dirname + '/EODreminder.js');
+
+// Update and overwrite the list of RAs who haven't submit their EODs
+function writeRAs() {
+  fs.writeFileSync(eodNames, '', 'utf8');
+
+  for (let i = 0; i < RAs.length; i += 1) {
+    if (RAs[i].length > 0) {
+      fs.appendFile(eodNames, `${RAs[i]}\n`)
+        .catch(err => console.log(err));
+    }
+  }
+}
+
+// Read the updated list of RAs
+function readRAs() {
+  RAs = fs.readFileSync(eodNames).toString().split('\n');
+}
+
+// Print the RAs who have submit their EODs yet for debugging
+function printRAs() {
+  console.log('Remaining RAs:');
+  for (let i = 0; i < (RAs.length - 1); i += 1) {
+    console.log(`${i}: ${RAs[i]}`);
+  }
+}
+
+// Remove name from EOD reminder list
+function submitEOD(RA) {
+  RAs = RAs.filter(name => name !== RA);
+  console.log(`${RA} has submitted EOD`);
+}
+
+// Checks if EOD reminder JavaScript is running or not
+function checkJSScript() {
+  const message = execSync('ps aux | grep EODreminder.js');
+  return message;
+}
+
+// Reads clock.txt to return the time
+function checkEODClock() {
+  if (fs.existsSync(clockPath)) {
+    const contents = fs.readFileSync(clockPath, 'utf8');
+    return (contents);
+  }
+  return ('Error: Clock does not exist!');
+}
+
+cp.fork(`${__dirname}/EODreminder.js`);
 
 app.server = http.createServer(app);
 
@@ -35,182 +82,140 @@ app.use(morgan('dev'));
 
 // 3rd party middleware
 app.use(cors({
-	exposedHeaders: config.corsHeaders
+  exposedHeaders: config.corsHeaders,
 }));
 
 app.use(bodyParser.urlencoded({
-  extended: true
+  extended: true,
 }));
 
 /** Reached by Slack API */
 
 // Slash command for submitting EOD's
 app.post('/eod', (req, res) => {
-    const slack_request = req.body;
+  const slackRequest = req.body;
 
-	const slack_response = {
-		"response_type": "in_channel",
-		"text": `:checkered_flag: EOD was submitted by *${slack_request.user_name}*`,
-		"attachments": [
-			{
-				"text": `${slack_request.text}`
-			}
-		]
-    };
+  const slackResponse = {
+    response_type: 'in_channel',
+    text: `:checkered_flag: EOD was submitted by *${slackRequest.user_name}*`,
+    attachments: [
+      {
+        text: `${slackRequest.text}`,
+      },
+    ],
+  };
 
-	axios.post(slack_request.response_url, slack_response).then(() => {
-		let report_data = JSON.parse(fs.readFileSync(data_file, 'utf8'));
-		report_data[slack_request.user_name] = {
-			'time': new Date(),
-			'text': slack_request.text,
-			'channel': slack_request.channel_name 
-		};
+  axios
+    .post(slackRequest.response_url, slackResponse)
+    .then(() => {
+      const reportData = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+      reportData[slackRequest.user_name] = {
+        time: new Date(),
+        text: slackRequest.text,
+        channel: slackRequest.channel_name,
+      };
 
-		fs.writeFileSync(data_file, JSON.stringify(report_data), 'utf8');
+      fs.writeFileSync(dataFile, JSON.stringify(reportData), 'utf8');
+    }).catch((error) => {
+      console.log(`error: ${error}`);
+    });
 
-    }).catch(error => {
-        console.log("error: " + error);
-	});
-    
-    // Remove RA's name from EOD reminder list
-    readRAs();
-    submitEOD(slack_request.user_name);
-    writeRAs();
-    printRAs();
-	res.status(200).send();
+  // Remove RA's name from EOD reminder list
+  readRAs();
+  submitEOD(slackRequest.user_name);
+  writeRAs();
+  printRAs();
+  res.status(200).send();
 });
 
 // Slash command for checking who have yet to submit EOD's
 app.post('/eod_left', (req, res) => {
-    const slack_request = req.body;
+  const slackRequest = req.body;
 
-    readRAs();
-    let message = "";
-    RAs.forEach((name) => {
-        message += name + '\n';
-    }); 
+  readRAs();
+  let message = '';
+  RAs.forEach((name) => {
+    message += `${name}\n`;
+  });
 
-	const slack_response = {
-		"response_type": "in_channel",
-        "text": `Sleepy RAs who haven't submitted their EODs:`, //"text": `Current time is: ` + clock + `\nSleepy RAs who haven't submitted their EODs:`
-        "attachments": [
-			{
-				"text": `${message}`
-			}
-		]
-    };
+  const slackResponse = {
+    response_type: 'in_channel',
+    text: 'Sleepy RAs who haven\'t submitted their EODs:',
+    attachments: [
+      {
+        text: `${message}`,
+      },
+    ],
+  };
 
-    axios.post(slack_request.response_url, slack_response).catch(error => {
-        console.log("error: " + error);
-	});
+  axios
+    .post(slackRequest.response_url, slackResponse)
+    .catch((error) => {
+      console.log(`error: ${error}`);
+    });
 
-    printRAs();
-	res.status(200).send();
+  printRAs();
+  res.status(200).send();
 });
 
 // Slash command for checking if remindEOD.js script is still running or not
 app.post('/check_js_script', (req, res) => {
-    const slack_request = req.body;
-    let message = checkJSScript();
+  const slackRequest = req.body;
+  const message = checkJSScript();
 
-	const slack_response = {
-		"response_type": "in_channel",
-        "text": `ps aux | grep EODreminder.js:`,
-        "attachments": [
-			{
-				"text": `${message}` //py_script
-			}
-		]
-    };
+  const slackResponse = {
+    response_type: 'in_channel',
+    text: 'ps aux | grep EODreminder.js:',
+    attachments: [
+      {
+        text: `${message}`, // py_script
+      },
+    ],
+  };
 
-    axios.post(slack_request.response_url, slack_response).catch(error => {
-        console.log("error: " + error);
-	});
-	res.status(200).send();
+  axios
+    .post(slackRequest.response_url, slackResponse)
+    .catch((error) => {
+      console.log(`error: ${error}`);
+    });
+
+  res.status(200).send();
 });
 
 // Slash command for checking remindEOD.py's time
 app.post('/check_eod_time', (req, res) => {
-    const slack_request = req.body;
+  const slackRequest = req.body;
 
-    let time = checkEODClock();
+  const time = checkEODClock();
 
-	const slack_response = {
-		"response_type": "in_channel",
-        "text": `EOD Reminder Bot's clock:`,
-        "attachments": [
-			{
-				"text": `${time}`
-			}
-		]
-    };
+  const slackResponse = {
+    response_type: 'in_channel',
+    text: 'EOD Reminder Bot\'s clock:',
+    attachments: [
+      {
+        text: `${time}`,
+      },
+    ],
+  };
 
-    axios.post(slack_request.response_url, slack_response).catch(error => {
-        console.log("error: " + error);
-	});
-	res.status(200).send();
+  axios
+    .post(slackRequest.response_url, slackResponse)
+    .catch((error) => {
+      console.log(`error: ${error}`);
+    });
+
+  res.status(200).send();
 });
-
-// Update and overwrite the list of RAs who haven't submit their EODs
-let writeRAs = () => {
-    fs.writeFileSync(eodNames, "", 'utf8');
-
-    for (let i = 0; i < RAs.length; i++){
-        if (RAs[i].length > 0) {
-            fs.appendFile(eodNames, RAs[i] + "\n", (err) => {
-                if(err) {
-                    return err;
-                }
-            });
-        }
-    }
-};
-
-// Read the updated list of RAs
-let readRAs = () => {
-    RAs = fs.readFileSync(eodNames).toString().split("\n");
-}
-
-// Print the RAs who have submit their EODs yet for debugging
-let printRAs = () => {
-    console.log ("Remaining RAs:")
-    for (let i = 0; i < (RAs.length - 1); i++){
-        console.log (i + ": " + RAs[i]);
-    }
-}
-
-// Remove name from EOD reminder list
-let submitEOD = (RA) => {
-    RAs = RAs.filter(name => name!=RA);
-    console.log(RA + " has submitted EOD")
-}
-
-// Checks if EOD reminder JavaScript is running or not
-let checkJSScript =() => {
-    let message = execSync('ps aux | grep EODreminder.js');
-    return message;
-}
-
-// Reads clock.txt to return the time
-let checkEODClock = () =>{
-    if (fs.existsSync(clock_path)) { 
-        let contents = fs.readFileSync(clock_path, 'utf8');
-        return (contents);
-    } else {
-        return ("Error: Clock does not exist!")
-    }
-}
 
 /** Get EODs */
 app.get('/eod', (req, res) => {
-	const report_data = JSON.parse(fs.readFileSync(data_file, 'utf8'));
-	res.status(200).json(report_data);
+  const reportData = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+  res.status(200).json(reportData);
 });
 
 app.server.listen(process.env.PORT || config.port, () => {
-    console.log(`Started on port ${app.server.address().port}`);
-    readRAs();
-    //printRAs();
+  console.log(`Started on port ${app.server.address().port}`);
+  readRAs();
 });
 
 export default app;

--- a/Osteppy/src/server.js
+++ b/Osteppy/src/server.js
@@ -10,6 +10,7 @@
 // slash commands such as /eod and /eod_left.
 ********************************************************* */
 
+import cp from 'child_process';
 import http from 'http';
 import path from 'path';
 import express from 'express';
@@ -23,9 +24,6 @@ import config from './config.json';
 const dataFile = path.join(__dirname, 'eods.json');
 const eodNames = path.join(__dirname, 'sleepyRAs.txt');
 const clockPath = path.join(__dirname, 'clock.txt');
-
-const { execSync } = require('child_process');
-const cp = require('child_process');
 
 let RAs = fs.readFileSync(eodNames).toString().split('\n');
 
@@ -62,7 +60,7 @@ function submitEOD(RA) {
 
 // Checks if EOD reminder JavaScript is running or not
 function checkJSScript() {
-  const message = execSync('ps aux | grep EODreminder.js');
+  const message = cp.execSync('ps aux | grep EODreminder.js');
   return message;
 }
 

--- a/Osteppy/src/server.js
+++ b/Osteppy/src/server.js
@@ -11,6 +11,7 @@
 ********************************************************* */
 
 import http from 'http';
+import path from 'path';
 import express from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
@@ -19,13 +20,14 @@ import axios from 'axios';
 import * as fs from 'fs';
 import config from './config.json';
 
-const app = express();
-const dataFile = './eods.json';
-const eodNames = `${__dirname}/sleepyRAs.txt`;
-let RAs = fs.readFileSync(eodNames).toString().split('\n');
-const clockPath = `${__dirname}/clock.txt`;
+const dataFile = path.join(__dirname, 'eods.json');
+const eodNames = path.join(__dirname, 'sleepyRAs.txt');
+const clockPath = path.join(__dirname, 'clock.txt');
+
 const { execSync } = require('child_process');
 const cp = require('child_process');
+
+let RAs = fs.readFileSync(eodNames).toString().split('\n');
 
 // Update and overwrite the list of RAs who haven't submit their EODs
 function writeRAs() {
@@ -74,6 +76,8 @@ function checkEODClock() {
 }
 
 cp.fork(`${__dirname}/EODreminder.js`);
+
+const app = express();
 
 app.server = http.createServer(app);
 

--- a/Osteppy/src/server.js
+++ b/Osteppy/src/server.js
@@ -18,7 +18,7 @@ import cors from 'cors';
 import morgan from 'morgan';
 import bodyParser from 'body-parser';
 import axios from 'axios';
-import * as fs from 'fs';
+import fs from 'fs';
 import config from './config.json';
 
 const dataFile = path.join(__dirname, 'eods.json');


### PR DESCRIPTION
Cleaned up a bunch of stuff in Osteppy:

- resolved lint issues per existing ESLint config
- allowed `console.log` statements as a NodeJS application
- cleaned up imports
- encapsulated EOD reporting as a class that manages in-memory data and persisting to files
  - did not reimplement `printRAs()` since it was a debugging function