### PR TITLE
Add rel="noopener noreferrer" to target="_blank"

### DIFF
--- a/Dashboard/src/components/Github.js
+++ b/Dashboard/src/components/Github.js
@@ -27,6 +27,7 @@ class Github extends Container {
                   <a 
                     href={`https://github.com/Seneca-CDOT/${entry.repoName}/tree/${entry.branchName}`}  
                     target="_blank"
+                    rel="noopener noreferrer"
                   >
                   <span className="github-repo github-link"> {` ${entry.repoName}/${entry.branchName}:`}</span>
                   </a>


### PR DESCRIPTION
From [Prevent usage of unsafe target='_blank' (react/jsx-no-target-blank)](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md):

> When creating a JSX element that has an `a` tag, it is often desired to have the link open in a new tab using the `target='_blank'` attribute. Using this attribute unaccompanied by `rel='noreferrer noopener'`, however, is a severe security vulnerability

See: https://mathiasbynens.github.io/rel-noopener/