### PR TITLE
Issues/108 GitHub whitelist

### DIFF
--- a/Github/Dockerfile
+++ b/Github/Dockerfile
@@ -18,6 +18,7 @@ COPY ./Github .
 # Add config file
 RUN mkdir /usr/src/config-files
 COPY ./config-files/github-token.json /usr/src/config-files
+COPY ./config-files/github-whitelist.json /usr/src/config-files
 
 EXPOSE 80
 CMD [ "npm", "start" ]

--- a/Github/service.js
+++ b/Github/service.js
@@ -35,7 +35,7 @@ module.exports.getRepos = recency => {
         } else {
           const reposNames = JSON.parse(data)
             .filter(rep => {
-              return (today - new Date(rep.pushed_at) < recency && whitelist.includes(rep.name));
+              return (whitelist.includes(rep.name) && today - new Date(rep.pushed_at) < recency);
             })
             .map(repo => {
               return {

--- a/Github/service.js
+++ b/Github/service.js
@@ -11,7 +11,7 @@
 const r = require('request');
 
 const { key } = require('../config-files/github-token');
-const { repos } = require('../config-files/github-whitelist');
+const { repos: whitelist } = require('../config-files/github-whitelist');
 const cdotUrl = 'https://api.github.com';
 const request = r.defaults({
   headers: { 'User-Agent': 'request' },
@@ -35,7 +35,7 @@ module.exports.getRepos = recency => {
         } else {
           const reposNames = JSON.parse(data)
             .filter(rep => {
-              return (today - new Date(rep.pushed_at) < recency && repos.includes(rep.name));
+              return (today - new Date(rep.pushed_at) < recency && whitelist.includes(rep.name));
             })
             .map(repo => {
               return {

--- a/Github/service.js
+++ b/Github/service.js
@@ -11,6 +11,7 @@
 const r = require('request');
 
 const { key } = require('../config-files/github-token');
+const { repos } = require('../config-files/github-whitelist');
 const cdotUrl = 'https://api.github.com';
 const request = r.defaults({
   headers: { 'User-Agent': 'request' },
@@ -34,7 +35,7 @@ module.exports.getRepos = recency => {
         } else {
           const reposNames = JSON.parse(data)
             .filter(rep => {
-              return (today - new Date(rep.pushed_at) < recency);
+              return (today - new Date(rep.pushed_at) < recency && repos.includes(rep.name));
             })
             .map(repo => {
               return {

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Create the above files in the `Dashboard/config-files/` directory.
 }
 ```
 
+##### `github-whitelist.json:`
+
+```
+{
+  repos: ["repo1", "repo2", "repo3"]
+}
+```
+
 ##### `id_rsa:`
 
 ```


### PR DESCRIPTION
Closes #108 

Dashboard will filter out repos not included in `config-files/github-whitelist.json` when fetching from github's API.

`github/whitelist.json`:
```json
{ 
  "repos": ["repo1", "repo2", "repo3"]
}
```
